### PR TITLE
photograph upload , download, delete from both database and S3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,16 @@ dependencies {
     implementation("com.graphql-java:graphiql-spring-boot-starter:5.0.2")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+
+    //Amazon S3
+
+    implementation (platform("com.amazonaws:aws-java-sdk-bom:1.11.1000"))
+    implementation ("com.amazonaws:aws-java-sdk-s3")
+    implementation("javax.xml.bind:jaxb-api")
+    //awssdk
+    implementation(platform("software.amazon.awssdk:bom:2.20.56"))
+    implementation("software.amazon.awssdk:s3")
+
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/java/com/experimental/product/community/membershipservice/client/request/UpdateMemberRequestV2.java
+++ b/src/main/java/com/experimental/product/community/membershipservice/client/request/UpdateMemberRequestV2.java
@@ -95,4 +95,8 @@ public class UpdateMemberRequestV2
         this.familyDetails = familyDetails;
         this.preferences = preferences;
     }
+    public UpdateMemberRequestV2()
+    {
+
+    }
 }

--- a/src/main/java/com/experimental/product/community/membershipservice/entity/MemberV2.java
+++ b/src/main/java/com/experimental/product/community/membershipservice/entity/MemberV2.java
@@ -5,6 +5,7 @@ import com.experimental.product.community.membershipservice.client.request.Creat
 import com.experimental.product.community.membershipservice.client.response.MemberResponseV2;
 import com.experimental.product.community.membershipservice.entity.auxilary.FamilyInfo2;
 import com.experimental.product.community.membershipservice.entity.auxilary.TypeValueInfo2;
+import com.experimental.product.community.membershipservice.image.ImageProperties;
 import nonapi.io.github.classgraph.json.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
@@ -40,6 +41,8 @@ public class MemberV2
     private List<FamilyInfo2> family=new ArrayList<>();
     @Field("joining_date")
     private LocalDateTime joiningDate = LocalDateTime.now();
+
+    private List<ImageProperties> images =new ArrayList<>() ;
 
 
 
@@ -216,6 +219,18 @@ public class MemberV2
         this.preferences=preferences;
         this.family=family;
 
+    }
+
+    public List<ImageProperties> getImages() {
+        return images;
+    }
+
+    public void setImages(List<ImageProperties> images) {
+        this.images = images;
+    }
+    public void addImage (ImageProperties image)
+    {
+        images.add(image);
     }
 
 }

--- a/src/main/java/com/experimental/product/community/membershipservice/image/ImageProperties.java
+++ b/src/main/java/com/experimental/product/community/membershipservice/image/ImageProperties.java
@@ -1,0 +1,31 @@
+package com.experimental.product.community.membershipservice.image;
+
+public class ImageProperties
+{
+    private String imageUrl;
+    private String imageKey;
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public void setImageKey(String imageKey) {
+        this.imageKey = imageKey;
+    }
+
+    public String getImageKey() {
+        return imageKey;
+    }
+
+
+
+    public ImageProperties(String imageUrl, String imageKey) {
+        this.imageUrl = imageUrl;
+        this.imageKey = imageKey;
+    }
+
+}

--- a/src/main/java/com/experimental/product/community/membershipservice/image/imageConfig/StorageConfig.java
+++ b/src/main/java/com/experimental/product/community/membershipservice/image/imageConfig/StorageConfig.java
@@ -1,0 +1,36 @@
+package com.experimental.product.community.membershipservice.image.imageConfig;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class StorageConfig
+{
+    @Value("${acessKey}")
+    private String acessKey;
+
+    @Value("${SecretKey}")
+    private String SecretKey;
+
+    @Value("${region}")
+    private String region;
+
+    @Value("${bucketName}")
+    private String bucketName;
+
+    @Bean
+    public AmazonS3 amazonS3()
+    {
+        AWSCredentials awsCredentials=new BasicAWSCredentials(acessKey,SecretKey);
+
+        return AmazonS3ClientBuilder.standard().withRegion(region).withCredentials(new AWSStaticCredentialsProvider(awsCredentials)).build();
+    }
+
+
+}

--- a/src/main/java/com/experimental/product/community/membershipservice/image/imageConfig/StorageConfig.java
+++ b/src/main/java/com/experimental/product/community/membershipservice/image/imageConfig/StorageConfig.java
@@ -13,23 +13,25 @@ import org.springframework.context.annotation.Configuration;
 public class StorageConfig
 {
     @Value("${acessKey}")
-    private String acessKey;
+    public String acessKey;
 
     @Value("${SecretKey}")
     private String SecretKey;
 
     @Value("${region}")
-    private String region;
+    public String region;
 
     @Value("${bucketName}")
-    private String bucketName;
+    public String bucketName;
 
     @Bean
     public AmazonS3 amazonS3()
     {
         AWSCredentials awsCredentials=new BasicAWSCredentials(acessKey,SecretKey);
-
-        return AmazonS3ClientBuilder.standard().withRegion(region).withCredentials(new AWSStaticCredentialsProvider(awsCredentials)).build();
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
     }
 
 

--- a/src/main/java/com/experimental/product/community/membershipservice/image/imageController/FileController.java
+++ b/src/main/java/com/experimental/product/community/membershipservice/image/imageController/FileController.java
@@ -1,0 +1,44 @@
+package com.experimental.product.community.membershipservice.image.imageController;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.experimental.product.community.membershipservice.image.imageService.FileService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/files")
+public class FileController
+{
+    @Autowired
+    private AmazonS3 s3client;
+    @Autowired
+    private FileService service;
+    @PostMapping("/upload")
+    public ResponseEntity<String> upload (@RequestParam(value = "file") MultipartFile file , @RequestParam(value = "id") String id) throws IOException {
+        return new ResponseEntity<>(service.uploadFile(file,id), HttpStatus.OK);
+    }
+
+    @GetMapping("/download")
+    public ResponseEntity<ByteArrayResource> download(@RequestParam(value = "key") String key)
+    {
+        byte[] data = service.downloadFile(key);
+        ByteArrayResource resource =new ByteArrayResource(data);
+        return ResponseEntity
+                .ok()
+                .header("content-type","application/octet-stream")
+                .header("content-disposition","attachment;filename=\""+key+"\"")
+                .body(resource);
+    }
+    @DeleteMapping("/delete/{id}")
+    public ResponseEntity<String> delete(@RequestParam(value = "key") String key ,@PathVariable String id)
+    {
+        return new ResponseEntity<>(service.deleteFile(key,id),HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/experimental/product/community/membershipservice/image/imageService/FileService.java
+++ b/src/main/java/com/experimental/product/community/membershipservice/image/imageService/FileService.java
@@ -1,0 +1,79 @@
+package com.experimental.product.community.membershipservice.image.imageService;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.PutObjectResult;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
+import com.experimental.product.community.membershipservice.entity.MemberV2;
+import com.experimental.product.community.membershipservice.image.ImageProperties;
+import com.experimental.product.community.membershipservice.repository.MemberRepositoryV2;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.utils.IoUtils;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+@Service
+public class FileService
+{
+    @Value("${bucketName}")
+    private String bucketName;
+    @Value("${region}")
+    private String region;
+
+    @Autowired
+    private AmazonS3 s3client;
+    @Autowired
+    private MemberRepositoryV2 memberRepositoryV2;
+    public String uploadFile(MultipartFile file, String id) throws IOException {
+        File convertedFile = convertMultipartFile(file);
+        PutObjectResult putObjectResult= s3client.putObject(new PutObjectRequest(bucketName,file.getOriginalFilename(),convertedFile));
+
+        String key = file.getOriginalFilename();
+        String objectUrl = String.format("https://%s.s3.%s.amazonaws.com/%s",
+                bucketName, region ,file.getOriginalFilename());
+        MemberV2 memberV2= memberRepositoryV2.findById(id).get();
+        ImageProperties imageProperties =new ImageProperties(objectUrl,key);
+        memberV2.addImage(imageProperties);
+        memberRepositoryV2.save(memberV2);
+        convertedFile.delete();
+        return key;
+    }
+    public byte[] downloadFile(String key)
+    {
+        S3Object s3Object=s3client.getObject(bucketName,key);
+        S3ObjectInputStream inputStream = s3Object.getObjectContent();
+        try {
+            byte[] content = IoUtils.toByteArray(inputStream);
+            return content;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String deleteFile(String key,String id)
+    {
+        s3client.deleteObject(bucketName,key);
+        MemberV2 memberV2= memberRepositoryV2.findById(id).get();
+        List<ImageProperties> images = memberV2.getImages();
+        images.removeIf(member->member.getImageKey().equals(key));
+        memberV2.setImages(images);
+        memberRepositoryV2.save(memberV2);
+        return "removed";
+    }
+
+    private File convertMultipartFile(MultipartFile file) throws IOException {
+        File convFile=new File(file.getOriginalFilename());
+        FileOutputStream fos=new FileOutputStream(convFile);
+        fos.write(file.getBytes());
+        fos.close();
+        return convFile;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,8 @@ spring.data.mongodb.user=communitymanager
 spring.data.mongodb.password=manager123
 spring.data.mongodb.authentication-database=admin
 spring.data.mongodb.authMode=SCRAM-SHA-1
+#Amazon S3
+acessKey=AKIAQDE2AA2PBPLY2LC2
+SecretKey=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
+bucketName=membershipservice
+region=us-east-2


### PR DESCRIPTION
3 new feature API are added to member ----

1. we can upload profile picture of any member . I am using Amazon AWS for cloud Storage so picture will upload in AWS membership service bucket . I am saving the access link of picture and picture key i.e original name in database.
2. using this key I am downloading the picture using download API.
3. using this key also I can delete the picture from both database and AWS bucket.